### PR TITLE
Fix: MiddlewaresをPromise関数にした

### DIFF
--- a/lib/helpers/ctxRegister.js
+++ b/lib/helpers/ctxRegister.js
@@ -6,16 +6,20 @@
  */
 'use strict'
 
+const co = require('co')
+
 /** @lends ctxRegister */
 function ctxRegister (creators) {
   return function middleware (ctx, next) {
-    Object.assign(
-      ctx,
-      ...Object.keys(creators).map((name) => ({
-        [name]: creators[ name ](ctx)
-      }))
-    )
-    next()
+    return co(function * () {
+      Object.assign(
+        ctx,
+        ...Object.keys(creators).map((name) => ({
+          [name]: creators[ name ](ctx)
+        }))
+      )
+      yield next()
+    })
   }
 }
 

--- a/lib/helpers/langDetector.js
+++ b/lib/helpers/langDetector.js
@@ -7,6 +7,7 @@
  */
 'use strict'
 
+const co = require('co')
 const { Locales } = require('locale')
 
 /** @lends langDetector */
@@ -17,10 +18,12 @@ function langDetector (locales, options = {}) {
 
   let supported = new Locales(locales, locales[ 0 ])
   return function middleware (ctx, next) {
-    let specified = ctx.query[ queryKey ] || ctx.get('accept-language')
-    let detected = new Locales(specified).best(supported)
-    ctx.lang = detected.language
-    next()
+    return co(function * () {
+      let specified = ctx.query[ queryKey ] || ctx.get('accept-language')
+      let detected = new Locales(specified).best(supported)
+      ctx.lang = detected.language
+      yield next()
+    })
   }
 }
 


### PR DESCRIPTION
middleware の next() は Promise を返す。
https://github.com/koajs/koa#middleware

endpoints内で Promise を使うとうまく機能しなかったので、原因をたどったらここでした。

参考: 現在の実装だと以下のendpointでエラーが起きる↓

```js
    endpoints: {
      '/api': {
      	GET: async (ctx) => {
      		await new Promise(done => {
      			setTimeout(done, 1000)
      		})
      		ctx.status = 201
      		ctx.body = 'ok'
      	}
      }
    }
```

```
AssertionError: headers have already been sent
```